### PR TITLE
drop users_bucket_lists if exists

### DIFF
--- a/db/migrate/20151013132941_users_bucket_lists.rb
+++ b/db/migrate/20151013132941_users_bucket_lists.rb
@@ -1,0 +1,8 @@
+class UsersBucketLists < ActiveRecord::Migration
+  def up
+    drop_table(:users_bucket_lists, if_exists: true)
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20151013132941_users_bucket_lists.rb
+++ b/db/migrate/20151013132941_users_bucket_lists.rb
@@ -1,8 +1,0 @@
-class UsersBucketLists < ActiveRecord::Migration
-  def up
-    drop_table(:users_bucket_lists, if_exists: true)
-  end
-
-  def down
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -59,11 +59,4 @@ ActiveRecord::Schema.define(version: 20151011232420) do
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
 
-  create_table "users_bucket_lists", force: :cascade do |t|
-    t.integer  "user_id",        null: false
-    t.integer  "bucket_list_id", null: false
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
-  end
-
 end


### PR DESCRIPTION
Fix failed rollback on users_bucket_lists join table after git reset where the table still existed on the schema after git reset to before the migration had been created.
