### PR TITLE
remove description attribute validation

### DIFF
--- a/spec/models/bucket_list_spec.rb
+++ b/spec/models/bucket_list_spec.rb
@@ -10,9 +10,6 @@ describe BucketList do
   it { should_not have_valid(:title).when(nil, " ") }
   it { should validate_uniqueness_of(:title) }
 
-  it { should have_valid(:description).when("Join me!", "Testing new car!") }
-  it { should_not have_valid(:description).when(12, 1.8) }
-
   it { should validate_inclusion_of(:is_public).in_array([true, false]) }
 
   it { should validate_presence_of(:user_id) }


### PR DESCRIPTION
Remove :description unit test because there is no reason to refuse integers 
