### PR TITLE
Fix adventures feature tests 03

### DIFF
--- a/app/controllers/adventures_controller.rb
+++ b/app/controllers/adventures_controller.rb
@@ -42,7 +42,6 @@ class AdventuresController < ApplicationController
     if @adventure.save
       flash[:notice] = "Excellent! Another adventure awaits!"
       redirect_to bucket_list_path(@bucket_list)
-      binding.pry
     else
       flash[:errors] = @adventure.errors.full_messages.join(" | ")
       render :new

--- a/app/controllers/adventures_controller.rb
+++ b/app/controllers/adventures_controller.rb
@@ -42,6 +42,7 @@ class AdventuresController < ApplicationController
     if @adventure.save
       flash[:notice] = "Excellent! Another adventure awaits!"
       redirect_to bucket_list_path(@bucket_list)
+      binding.pry
     else
       flash[:errors] = @adventure.errors.full_messages.join(" | ")
       render :new

--- a/app/models/adventure.rb
+++ b/app/models/adventure.rb
@@ -8,10 +8,7 @@ class Adventure < ActiveRecord::Base
   accepts_nested_attributes_for :bucket_lists
   accepts_nested_attributes_for :bucket_list_adventures
 
-  # validates :name, presence: true, unless: :address?
-  # validates :address, presence: true, unless: :name?
   validate :name_or_address
-
 
   validates :latitude, numericality: { only_float: true, allow_blank: true }
   validates :longitude, numericality: { only_float: true, allow_blank: true }
@@ -34,9 +31,9 @@ class Adventure < ActiveRecord::Base
 
   private
 
-    def name_or_address
-      if name.blank? && address.blank?
-        errors.add(:adventure, "Must specify a name and/or address")
-      end
+  def name_or_address
+    if name.blank? && address.blank?
+      errors.add(:adventure, "Must specify a name and/or address")
     end
+  end
 end

--- a/app/models/adventure.rb
+++ b/app/models/adventure.rb
@@ -8,8 +8,11 @@ class Adventure < ActiveRecord::Base
   accepts_nested_attributes_for :bucket_lists
   accepts_nested_attributes_for :bucket_list_adventures
 
-  validates :name, presence: true, unless: :address?
-  validates :address, presence: true, unless: :name?
+  # validates :name, presence: true, unless: :address?
+  # validates :address, presence: true, unless: :name?
+  validate :name_or_address
+
+
   validates :latitude, numericality: { only_float: true, allow_blank: true }
   validates :longitude, numericality: { only_float: true, allow_blank: true }
 
@@ -28,4 +31,12 @@ class Adventure < ActiveRecord::Base
   reverse_geocoded_by :latitude, :longitude, address: :address
   after_validation :reverse_geocode  # auto-fetch address
   after_validation :geocode, if: ->(obj){ obj.address.present? and obj.address_changed? }
+
+  private
+
+    def name_or_address
+      if name.blank? && address.blank?
+        errors.add(:adventure, "Must specify a name and/or address")
+      end
+    end
 end

--- a/spec/features/adventures/user_creates_new_adventure_spec.rb
+++ b/spec/features/adventures/user_creates_new_adventure_spec.rb
@@ -26,11 +26,11 @@ feature "user creates an adventure", %(
     expect(page).to have_content("Excellent! Another adventure awaits!")
   end
 
-  # scenario "authenticated user does not specify either name or address" do
-  #   bucket_list_sign_in
-  #   visit new_adventure_path
-  #   click_button "Toss it in!"
-  #
-  #   expect(page).not_to have_content("Excellent! Another adventure awaits!")
-  # end
+  scenario "authenticated user does not specify either name or address" do
+    bucket_list_sign_in
+    visit new_adventure_path
+    click_button "Toss it in!"
+
+    expect(page).not_to have_content("Excellent! Another adventure awaits!")
+  end
 end

--- a/spec/features/adventures/user_creates_new_adventure_spec.rb
+++ b/spec/features/adventures/user_creates_new_adventure_spec.rb
@@ -30,7 +30,9 @@ feature "user creates an adventure", %(
     bucket_list_sign_in
     visit new_adventure_path
     click_button "Toss it in!"
+    save_and_open_page
 
+    expect(page).to have_content("Must specify a name and/or address")
     expect(page).not_to have_content("Excellent! Another adventure awaits!")
   end
 end

--- a/spec/features/adventures/user_creates_new_adventure_spec.rb
+++ b/spec/features/adventures/user_creates_new_adventure_spec.rb
@@ -24,13 +24,13 @@ feature "user creates an adventure", %(
     click_button "Toss it in!"
 
     expect(page).to have_content("Excellent! Another adventure awaits!")
+    expect(page).not_to have_content("Must specify a name and/or address")
   end
 
   scenario "authenticated user does not specify either name or address" do
     bucket_list_sign_in
     visit new_adventure_path
     click_button "Toss it in!"
-    save_and_open_page
 
     expect(page).to have_content("Must specify a name and/or address")
     expect(page).not_to have_content("Excellent! Another adventure awaits!")


### PR DESCRIPTION
- create custom either/or validation w/ custom message for name and address attributes on adventure model
- fix user does not specify both name and address feature test & pass
- add negative page expectations to 2 adventure feature tests: "user does not specify both name and address" and "authenticated user successfully creates a new adventure"
- pass above 2 tests w/ negative page expectations
