### PR TITLE
add unauthenticated user fails to create new adventure feature test

### DIFF
--- a/spec/features/adventures/user_creates_new_adventure_spec.rb
+++ b/spec/features/adventures/user_creates_new_adventure_spec.rb
@@ -44,5 +44,4 @@ feature "user creates an adventure", %(
     expect(page).not_to have_content("Address")
     expect(page).not_to have_content("New Adventure")
   end
-
 end

--- a/spec/features/adventures/user_creates_new_adventure_spec.rb
+++ b/spec/features/adventures/user_creates_new_adventure_spec.rb
@@ -35,4 +35,14 @@ feature "user creates an adventure", %(
     expect(page).to have_content("Must specify a name and/or address")
     expect(page).not_to have_content("Excellent! Another adventure awaits!")
   end
+
+  scenario "unauthenticated user fails to create a new adventure" do
+    visit new_adventure_path
+
+    expect(page).to have_content("You can do that after you sign in or sign up!")
+    expect(page).to have_content("Sign In")
+    expect(page).not_to have_content("Address")
+    expect(page).not_to have_content("New Adventure")
+  end
+
 end


### PR DESCRIPTION
- add feature test for unauthenticated user fails to create a new adventure & pass test
