### PR TITLE
Refactor adventures feature tests 11

### DIFF
--- a/app/controllers/adventures_controller.rb
+++ b/app/controllers/adventures_controller.rb
@@ -66,7 +66,7 @@ class AdventuresController < ApplicationController
       flash[:info] = "Changes saved!"
     else
       @adventure = Adventure.where(user: current_user)[0]
-      flash[:warning] = "Every Adventure needs a name."
+      flash[:errors] = @adventure.errors.full_messages.join(" | ")
       render :edit
     end
   end

--- a/app/controllers/adventures_controller.rb
+++ b/app/controllers/adventures_controller.rb
@@ -65,7 +65,6 @@ class AdventuresController < ApplicationController
       redirect_to root_path
       flash[:info] = "Changes saved!"
     else
-      @adventure = Adventure.where(user: current_user)[0]
       flash[:errors] = @adventure.errors.full_messages.join(" | ")
       render :edit
     end

--- a/app/views/adventures/edit.html.erb
+++ b/app/views/adventures/edit.html.erb
@@ -29,8 +29,8 @@
         <%= ff.text_area :notes %>
 
         <div class="text-center">
-          <%= ff.check_box :is_achieved %>
           <%= ff.label :is_achieved, "Seen it!  Done it!"  %>
+          <%= ff.check_box :is_achieved %>
         </div>
 
       <% end %>

--- a/spec/features/adventures/user_edits_adventure_spec.rb
+++ b/spec/features/adventures/user_edits_adventure_spec.rb
@@ -119,4 +119,17 @@ feature "user edits adventure", %(
     expect(page).to have_content("Changes saved!")
     expect(page).not_to have_content("Must specify a name and/or address")
   end
+
+  scenario "authenticated user fails to edit an adventure" do
+    bucket_list_sign_in
+    adventure = FactoryGirl.create(:adventure)
+
+    visit edit_adventure_path(adventure)
+    fill_in "Name", with: ""
+    fill_in "Address", with: ""
+    click_button "Save It!"
+
+    expect(page).to have_content("Must specify a name and/or address")
+    expect(page).not_to have_content("Changes saved!")
+  end
 end

--- a/spec/features/adventures/user_edits_adventure_spec.rb
+++ b/spec/features/adventures/user_edits_adventure_spec.rb
@@ -38,6 +38,7 @@ feature "user edits adventure", %(
     )
 
     visit edit_adventure_path(adventure)
+    save_and_open_page
     fill_in "Notes", with: "Avoid crocodiles, wear sunscreen"
     checkbox = find_by_id("adventure_bucket_list_adventures_attributes_0_is_achieved")
     check "Seen it! Done it!"
@@ -94,18 +95,18 @@ feature "user edits adventure", %(
     expect(page).not_to have_content("Changes saved!")
   end
 
-  # scenario "authenticated user fails to edit an adventure" do
-  #   bucket_list_sign_in
-  #   adventure = FactoryGirl.create(:adventure, address: nil)
-  #
-  #   visit edit_adventure_path(adventure)
-  #   fill_in "Name", with: ""
-  #   save_and_open_page
-  #   click_button "Save It!"
-  #
-  #   expect(page).to have_content("Must specify a name and/or address")
-  #   expect(page).not_to have_content("Changes saved!")
-  # end
+  scenario "authenticated user fails to edit an adventure" do
+    bucket_list_sign_in
+    adventure = FactoryGirl.create(:adventure)
+
+    visit edit_adventure_path(adventure)
+    fill_in "Name", with: ""
+    fill_in "Address", with: ""
+    click_button "Save It!"
+
+    expect(page).to have_content("Must specify a name and/or address")
+    expect(page).not_to have_content("Changes saved!")
+  end
 
   scenario "authenticated user successfully removes adventure name attribute" do
     bucket_list_sign_in

--- a/spec/features/adventures/user_edits_adventure_spec.rb
+++ b/spec/features/adventures/user_edits_adventure_spec.rb
@@ -38,7 +38,6 @@ feature "user edits adventure", %(
     )
 
     visit edit_adventure_path(adventure)
-    save_and_open_page
     fill_in "Notes", with: "Avoid crocodiles, wear sunscreen"
     checkbox = find_by_id("adventure_bucket_list_adventures_attributes_0_is_achieved")
     check "Seen it! Done it!"
@@ -97,11 +96,10 @@ feature "user edits adventure", %(
 
   scenario "authenticated user fails to edit an adventure" do
     bucket_list_sign_in
-    adventure = FactoryGirl.create(:adventure)
+    adventure = FactoryGirl.create(:adventure, address: nil)
 
     visit edit_adventure_path(adventure)
-    fill_in "Name", with: ""
-    fill_in "Address", with: ""
+    find("input[id$='adventure_name']").set ""
     click_button "Save It!"
 
     expect(page).to have_content("Must specify a name and/or address")

--- a/spec/features/adventures/user_edits_adventure_spec.rb
+++ b/spec/features/adventures/user_edits_adventure_spec.rb
@@ -94,6 +94,19 @@ feature "user edits adventure", %(
     expect(page).not_to have_content("Changes saved!")
   end
 
+  # scenario "authenticated user fails to edit an adventure" do
+  #   bucket_list_sign_in
+  #   adventure = FactoryGirl.create(:adventure, address: nil)
+  #
+  #   visit edit_adventure_path(adventure)
+  #   fill_in "Name", with: ""
+  #   save_and_open_page
+  #   click_button "Save It!"
+  #
+  #   expect(page).to have_content("Must specify a name and/or address")
+  #   expect(page).not_to have_content("Changes saved!")
+  # end
+
   scenario "authenticated user successfully removes adventure name attribute" do
     bucket_list_sign_in
     adventure = FactoryGirl.create(:adventure)
@@ -118,18 +131,5 @@ feature "user edits adventure", %(
 
     expect(page).to have_content("Changes saved!")
     expect(page).not_to have_content("Must specify a name and/or address")
-  end
-
-  scenario "authenticated user fails to edit an adventure" do
-    bucket_list_sign_in
-    adventure = FactoryGirl.create(:adventure)
-
-    visit edit_adventure_path(adventure)
-    fill_in "Name", with: ""
-    fill_in "Address", with: ""
-    click_button "Save It!"
-
-    expect(page).to have_content("Must specify a name and/or address")
-    expect(page).not_to have_content("Changes saved!")
   end
 end


### PR DESCRIPTION
- add feature test for authenticated user edits required adventure fields to have nil value (causes save fail)
- refactor form_for in adventure views for readability
- remove line in adventure controller update method where @adventure was reassigned to where user: current_user on save fail
- change adventure save fail warning to error message
