### PR TITLE
Adventure location feature tests 01

### DIFF
--- a/spec/features/adventures/user_creates_new_adventure_with_location_spec.rb
+++ b/spec/features/adventures/user_creates_new_adventure_with_location_spec.rb
@@ -31,7 +31,7 @@ feature "authenticated user creates a an adventure using google maps", %(
     save_and_open_page
     fill_in "Name", with: nil
     fill_in "Location", with: nil
-    click_button "Add to Bucket List!"
+    click_button "Toss it in!"
 
     expect(page).to have_content("Must specify a name and/or address")
     expect(page).not_to have_content("Excellent!  Another adventure to happen!")

--- a/spec/features/adventures/user_creates_new_adventure_with_location_spec.rb
+++ b/spec/features/adventures/user_creates_new_adventure_with_location_spec.rb
@@ -26,9 +26,11 @@ feature "authenticated user creates a an adventure using google maps", %(
   #
   scenario "authenticated user fails to add an adventure to an " +
     "existing bucket list with address only" do
+    bucket_list_sign_in
     visit new_adventure_path
     save_and_open_page
-    fill_in "Name", with: "x"
+    fill_in "Name", with: nil
+    fill_in "Address", with: nil
     click_button "Add to Bucket List!"
 
     expect(page).to have_content("Must specify a name and/or address")

--- a/spec/features/adventures/user_creates_new_adventure_with_location_spec.rb
+++ b/spec/features/adventures/user_creates_new_adventure_with_location_spec.rb
@@ -26,11 +26,9 @@ feature "authenticated user creates a an adventure using google maps", %(
   #
   scenario "authenticated user fails to add an adventure to an " +
     "existing bucket list with address only" do
-    bucket_list_sign_in
     visit new_adventure_path
     save_and_open_page
     fill_in "Name", with: "x"
-    select bucket_list.title, from: "Bucket list"
     click_button "Add to Bucket List!"
 
     expect(page).to have_content("Must specify a name and/or address")

--- a/spec/features/adventures/user_creates_new_adventure_with_location_spec.rb
+++ b/spec/features/adventures/user_creates_new_adventure_with_location_spec.rb
@@ -30,7 +30,7 @@ feature "authenticated user creates a an adventure using google maps", %(
     visit new_adventure_path
     save_and_open_page
     fill_in "Name", with: nil
-    fill_in "Address", with: nil
+    fill_in "Location", with: nil
     click_button "Add to Bucket List!"
 
     expect(page).to have_content("Must specify a name and/or address")

--- a/spec/features/adventures/user_creates_new_adventure_with_location_spec.rb
+++ b/spec/features/adventures/user_creates_new_adventure_with_location_spec.rb
@@ -27,8 +27,8 @@ feature "authenticated user creates a an adventure using google maps", %(
   scenario "authenticated user fails to add an adventure to an " +
     "existing bucket list with address only" do
     bucket_list_sign_in
+
     visit new_adventure_path
-    save_and_open_page
     fill_in "Name", with: nil
     fill_in "Location", with: nil
     click_button "Toss it in!"

--- a/spec/features/adventures/user_creates_new_adventure_with_location_spec.rb
+++ b/spec/features/adventures/user_creates_new_adventure_with_location_spec.rb
@@ -24,16 +24,17 @@ feature "authenticated user creates a an adventure using google maps", %(
   #   expect(page).to have_content("I've already been here/done this")
   # end
   #
-  # scenario "authenticated user fails to add an adventure to an " +
-  #   "existing bucket list with address only" do
-  #   bucket_list_sign_in
-  #   visit new_adventure_path
-  #   fill_in "Address", with: "x"
-  #   select bucket_list.title, from: "Bucket list"
-  #   click_button "Add to Bucket List!"
-  #
-  #   expect(page).to have_content("Must specify a name and/or address")
-  #   expect(page).not_to have_content("Excellent!  Another adventure to happen!")
-  #   expect(page).not_to have_content("I've already been here/done this")
-  # end
+  scenario "authenticated user fails to add an adventure to an " +
+    "existing bucket list with address only" do
+    bucket_list_sign_in
+    visit new_adventure_path
+    save_and_open_page
+    fill_in "Name", with: "x"
+    select bucket_list.title, from: "Bucket list"
+    click_button "Add to Bucket List!"
+
+    expect(page).to have_content("Must specify a name and/or address")
+    expect(page).not_to have_content("Excellent!  Another adventure to happen!")
+    expect(page).not_to have_content("I've already been here/done this")
+  end
 end


### PR DESCRIPTION
- pass authenticated user fails to create a new adventure due to leaving Name and Address fields both blank in adventure feature test
