### PR TITLE
Add link to adventures feature test

### DIFF
--- a/app/views/adventures/edit.html.erb
+++ b/app/views/adventures/edit.html.erb
@@ -15,6 +15,9 @@
       <%= f.label :address %>
       <%= f.text_area :address %>
 
+      <%= f.label :link %>
+      <%= f.text_area :link %>
+
       <%= f.fields_for :bucket_list_adventures do |ff| %>
 
         <%= ff.label :bucket_list_id %>

--- a/app/views/adventures/new.html.erb
+++ b/app/views/adventures/new.html.erb
@@ -11,6 +11,9 @@
         <%= f.label :address, "Location" %>
         <%= f.text_area :address %>
 
+        <%= f.label :link %>
+        <%= f.text_area :link %>
+
         <%= f.fields_for :bucket_list_adventures do |ff| %>
 
           <%= ff.label :bucket_list_id %>

--- a/db/migrate/20151222211002_add_link_attribute_to_adventure.rb
+++ b/db/migrate/20151222211002_add_link_attribute_to_adventure.rb
@@ -2,7 +2,7 @@ class AddLinkAttributeToAdventure < ActiveRecord::Migration
   def up
     add_column :adventures, :link, :string
   end
-  
+
   def down
     remove_column :adventures, :link
   end

--- a/db/migrate/20151222211002_add_link_attribute_to_adventure.rb
+++ b/db/migrate/20151222211002_add_link_attribute_to_adventure.rb
@@ -1,4 +1,8 @@
 class AddLinkAttributeToAdventure < ActiveRecord::Migration
-  def change
+  def up
+    add_column :adventures, :link, :string
+  end
+  def down
+    remove_column :adventures, :link
   end
 end

--- a/db/migrate/20151222211002_add_link_attribute_to_adventure.rb
+++ b/db/migrate/20151222211002_add_link_attribute_to_adventure.rb
@@ -2,6 +2,7 @@ class AddLinkAttributeToAdventure < ActiveRecord::Migration
   def up
     add_column :adventures, :link, :string
   end
+  
   def down
     remove_column :adventures, :link
   end

--- a/db/migrate/20151222211002_add_link_attribute_to_adventure.rb
+++ b/db/migrate/20151222211002_add_link_attribute_to_adventure.rb
@@ -1,0 +1,4 @@
+class AddLinkAttributeToAdventure < ActiveRecord::Migration
+  def change
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151024023304) do
+ActiveRecord::Schema.define(version: 20151222211002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 20151024023304) do
     t.float    "longitude"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string   "link"
   end
 
   create_table "bucket_list_adventures", force: :cascade do |t|

--- a/spec/features/adventures/user_creates_new_adventure_spec.rb
+++ b/spec/features/adventures/user_creates_new_adventure_spec.rb
@@ -8,13 +8,14 @@ feature "user creates an adventure", %(
   # Acceptance Criteria
   # [x] I must be signed in to add an adventure
   # [x] I must create a bucket list before I can create an adventure
-  # [x] I must provide a either a name, address, or both
-  # [x] If I do not provide a name or address, I recieve an error message
+  # [x] I must provide a either a name, location, or both
+  # [x] If I do not provide a name or location, I recieve an error message
   # [x] I may include text notes about the adventure
   # [x] I may mark the adventure as achieved if I choose
   # [x] By defalut, the adventure is marked as not achieved
   # [x] I can select the bucket list I would like to add my adventure to from
   #    a dropdown list
+  # [] I may include a link by pasting the location
   # [x] I recieve a success message when I successfully add an adventure
 
   scenario "authenticated user successfully creates an adventure" do
@@ -28,7 +29,7 @@ feature "user creates an adventure", %(
   end
 
   scenario "authenticated user successfully creates an adventure w/ " \
-    "non-required attributes" do
+    "notes and achieved attributes" do
     bucket_list_sign_in
     visit new_adventure_path
     fill_in "Name", with: "Swim the Nile"
@@ -57,6 +58,23 @@ feature "user creates an adventure", %(
     expect(page).to have_content("Excellent! Another adventure awaits!")
     expect(page).not_to have_content("Must specify a name and/or address")
   end
+
+  scenario "authenticated user successfully creates an adventure w/ " \
+    "link attribute" do
+    bucket_list_sign_in
+    visit new_adventure_path
+    fill_in "Name", with: "Underground River"
+    fill_in "Location", with: "Underground River Palawan Philippines"
+    fill_in "Link", with: "https://en.wikipedia.org/wiki/Puerto_Princesa_Subterranean_River_National_Park"
+    checkbox = find_by_id("adventure_bucket_list_adventures_attributes_0_is_achieved")
+    check "Seen it! Done it!"
+    click_button "Toss it in!"
+
+    expect(checkbox).to be_checked
+    expect(page).to have_content("Excellent! Another adventure awaits!")
+    expect(page).not_to have_content("Must specify a name and/or address")
+  end
+
 
   scenario "authenticated user does not specify either name or address" do
     bucket_list_sign_in

--- a/spec/features/adventures/user_creates_new_adventure_spec.rb
+++ b/spec/features/adventures/user_creates_new_adventure_spec.rb
@@ -65,7 +65,7 @@ feature "user creates an adventure", %(
     bucket_list_sign_in
     visit new_adventure_path
     fill_in "Name", with: "Underground River"
-    fill_in "Address", with: "Underground River Palawan Philippines"
+    fill_in "Location", with: "Underground River Palawan Philippines"
     fill_in "Link", with: "https://en.wikipedia.org/wiki/Puerto_Princesa_Subterranean_River_National_Park"
     checkbox = find_by_id("adventure_bucket_list_adventures_attributes_0_is_achieved")
     check "Seen it! Done it!"

--- a/spec/features/adventures/user_creates_new_adventure_spec.rb
+++ b/spec/features/adventures/user_creates_new_adventure_spec.rb
@@ -15,7 +15,7 @@ feature "user creates an adventure", %(
   # [x] By defalut, the adventure is marked as not achieved
   # [x] I can select the bucket list I would like to add my adventure to from
   #    a dropdown list
-  # [] I may include a link by pasting the location
+  # [] I may include a link by submitting the address
   # [x] I recieve a success message when I successfully add an adventure
 
   scenario "authenticated user successfully creates an adventure" do
@@ -43,7 +43,8 @@ feature "user creates an adventure", %(
     expect(page).not_to have_content("Must specify a name and/or address")
   end
 
-  scenario "authenticated user successfully selects a bucket list" do
+  scenario "authenticated user successfully creates adventure and selects a " \
+  "bucket list" do
     bucket_list_sign_in
     visit new_bucket_list_path
     fill_in "Title", with: "North Africa"

--- a/spec/features/adventures/user_creates_new_adventure_spec.rb
+++ b/spec/features/adventures/user_creates_new_adventure_spec.rb
@@ -75,7 +75,7 @@ feature "user creates an adventure", %(
     expect(page).to have_content("Excellent! Another adventure awaits!")
     expect(page).not_to have_content("Must specify a name and/or address")
   end
-  
+
   scenario "authenticated user does not specify either name or address" do
     bucket_list_sign_in
     visit new_adventure_path

--- a/spec/features/adventures/user_creates_new_adventure_spec.rb
+++ b/spec/features/adventures/user_creates_new_adventure_spec.rb
@@ -75,8 +75,7 @@ feature "user creates an adventure", %(
     expect(page).to have_content("Excellent! Another adventure awaits!")
     expect(page).not_to have_content("Must specify a name and/or address")
   end
-
-
+  
   scenario "authenticated user does not specify either name or address" do
     bucket_list_sign_in
     visit new_adventure_path

--- a/spec/features/adventures/user_creates_new_adventure_spec.rb
+++ b/spec/features/adventures/user_creates_new_adventure_spec.rb
@@ -8,8 +8,8 @@ feature "user creates an adventure", %(
   # Acceptance Criteria
   # [x] I must be signed in to add an adventure
   # [x] I must create a bucket list before I can create an adventure
-  # [x] I must provide a either a name, location, or both
-  # [x] If I do not provide a name or location, I recieve an error message
+  # [x] I must provide a either a name, address, or both
+  # [x] If I do not provide a name or address, I recieve an error message
   # [x] I may include text notes about the adventure
   # [x] I may mark the adventure as achieved if I choose
   # [x] By defalut, the adventure is marked as not achieved
@@ -65,7 +65,7 @@ feature "user creates an adventure", %(
     bucket_list_sign_in
     visit new_adventure_path
     fill_in "Name", with: "Underground River"
-    fill_in "Location", with: "Underground River Palawan Philippines"
+    fill_in "Address", with: "Underground River Palawan Philippines"
     fill_in "Link", with: "https://en.wikipedia.org/wiki/Puerto_Princesa_Subterranean_River_National_Park"
     checkbox = find_by_id("adventure_bucket_list_adventures_attributes_0_is_achieved")
     check "Seen it! Done it!"

--- a/spec/features/adventures/user_edits_adventure_spec.rb
+++ b/spec/features/adventures/user_edits_adventure_spec.rb
@@ -84,6 +84,30 @@ feature "user edits adventure", %(
     expect(page).not_to have_content("Must specify a name and/or address")
   end
 
+  scenario "authenticated user successfully adds a address to an adventure" do
+    bucket_list_sign_in
+    adventure = FactoryGirl.create(:adventure, address: nil)
+
+    visit edit_adventure_path(adventure)
+    fill_in "Address", with: "Spain"
+    click_button "Save It!"
+
+    expect(page).to have_content("Changes saved!")
+    expect(page).not_to have_content("Must specify a name and/or address")
+  end
+
+  scenario "authenticated user successfully adds a name to an adventure" do
+    bucket_list_sign_in
+    adventure = FactoryGirl.create(:adventure, name: nil)
+
+    visit edit_adventure_path(adventure)
+    fill_in "Name", with: "Do this thing!"
+    click_button "Save It!"
+
+    expect(page).to have_content("Changes saved!")
+    expect(page).not_to have_content("Must specify a name and/or address")
+  end
+
   scenario "unauthenticated user fails to edit an adventure" do
     adventure = FactoryGirl.create(:adventure)
 

--- a/spec/features/adventures/user_edits_adventure_spec.rb
+++ b/spec/features/adventures/user_edits_adventure_spec.rb
@@ -84,6 +84,18 @@ feature "user edits adventure", %(
     expect(page).not_to have_content("Must specify a name and/or address")
   end
 
+  scenario "authenticated user successfully adds a link to an adventure" do
+    bucket_list_sign_in
+    adventure = FactoryGirl.create(:adventure)
+
+    visit edit_adventure_path(adventure)
+    fill_in "Link", with: "https://en.wikipedia.org/wiki/List_of_caves_in_Vietnam"
+    click_button "Save It!"
+
+    expect(page).to have_content("Changes saved!")
+    expect(page).not_to have_content("Must specify a name and/or address")
+  end
+
   scenario "authenticated user successfully adds a address to an adventure" do
     bucket_list_sign_in
     adventure = FactoryGirl.create(:adventure, address: nil)


### PR DESCRIPTION
- incorporate link attribute into existing adventure feature test for user successfully creates a new adventure
- add feature test for user successfully edits existing adventure to add link
- add feature tests for user successfully adds name attribute to existing adventure with location only
- add feature tests for user successfully adds location attribute to existing adventure with name only
- create migration to add link column to adventures table & migrate
