### PR TITLE
Add feature test user views adventures index

### DIFF
--- a/app/views/adventures/index.html.erb
+++ b/app/views/adventures/index.html.erb
@@ -1,0 +1,33 @@
+<div class="row">
+  <div class="small-11 medium-6 columns small-centered">
+    <h3>My Adventures:</h3>
+
+    <p><%= @adventures.count %> Adventure(s) </p>
+
+    <ul class="no-bullet">
+      <% @adventures.each do |adventure| %>
+        <li class="bucket-list">
+          <div class="small-9 columns small-centered divinding-line"></div>
+          <h4><%= link_to adventure.name, adventure_path(adventure.id) unless adventure.name.nil? %></h4>
+          <h4><%= link_to adventure.address, adventure_path(adventure.id) unless adventure.address.nil? %></h4>
+          <% if adventure.is_shared %>
+            <h6>
+              <%= fa_icon "eye" %>
+              Public
+            </h6>
+          <% else %>
+            <h6><%= fa_icon "eye-slash" %> Private</h6>
+          <% end %>
+          <% if adventure.is_achieved %>
+            <%= link_to (fa_icon "check-square-o") + " Seen it! Done it!",
+              "#", class: "achieved-toggle", id: adventure.id %>
+          <% else %>
+            <%= link_to (fa_icon "square-o") + " Seen it! Done it!",
+              "#", class: "achieved-toggle", id: adventure.id %>
+          <% end %>
+          <%= link_to "Edit", edit_adventure_path(adventure) %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/app/views/adventures/show.html.erb
+++ b/app/views/adventures/show.html.erb
@@ -10,7 +10,7 @@
       <% else %>
         <%= fa_icon "eye-slash" %> Private /
       <% end %>
-          <%= link_to "Edit", edit_adventure_path(@adventure) %>
+      <%= link_to "Edit", edit_adventure_path(@adventure) %>
       </h6>
         <% if @adventure.is_achieved %>
           <%= link_to (fa_icon "check-square-o") + " Seen it! Done it!",

--- a/spec/features/adventures/user_creates_new_adventure_spec.rb
+++ b/spec/features/adventures/user_creates_new_adventure_spec.rb
@@ -19,7 +19,8 @@ feature "user creates an adventure", %(
   # [x] I recieve a success message when I successfully add an adventure
 
   scenario "authenticated user successfully creates an adventure" do
-    bucket_list_sign_in
+    user = FactoryGirl.create(:user)
+    bucket_list_sign_in(user)
     visit new_adventure_path
     fill_in "Name", with: "Swim the Nile"
     click_button "Toss it in!"
@@ -30,7 +31,8 @@ feature "user creates an adventure", %(
 
   scenario "authenticated user successfully creates an adventure w/ " \
     "unrequired attributes" do
-    bucket_list_sign_in
+    user = FactoryGirl.create(:user)
+    bucket_list_sign_in(user)
     visit new_adventure_path
     fill_in "Name", with: "Swim the Nile"
     fill_in "Notes", with: "Avoid crocodiles, wear sunscreen"
@@ -49,7 +51,8 @@ feature "user creates an adventure", %(
 
   scenario "authenticated user successfully creates adventure and selects a " \
   "bucket list" do
-    bucket_list_sign_in
+    user = FactoryGirl.create(:user)
+    bucket_list_sign_in(user)
 
     visit new_adventure_path
     fill_in "Name", with: "Swim the Nile"
@@ -63,7 +66,8 @@ feature "user creates an adventure", %(
 
   scenario "authenticated user successfully creates an adventure w/ " \
     "link attribute" do
-    bucket_list_sign_in
+    user = FactoryGirl.create(:user)
+    bucket_list_sign_in(user)
     visit new_adventure_path
     fill_in "Name", with: "Underground River"
     fill_in "Location", with: "Underground River Palawan Philippines"
@@ -81,7 +85,8 @@ feature "user creates an adventure", %(
   end
 
   scenario "authenticated user does not specify either name or address" do
-    bucket_list_sign_in
+    user = FactoryGirl.create(:user)
+    bucket_list_sign_in(user)
     visit new_adventure_path
     click_button "Toss it in!"
 
@@ -100,7 +105,8 @@ feature "user creates an adventure", %(
 
   scenario "authenticated user fails to create and adventure due to " \
     "no bucket_lists (0 count)" do
-    sign_in
+    user = FactoryGirl.create(:user)
+    sign_in(user)
     visit new_adventure_path
 
     expect(page).to have_content("You don't have any bucket lists yet")

--- a/spec/features/adventures/user_creates_new_adventure_with_location_spec.rb
+++ b/spec/features/adventures/user_creates_new_adventure_with_location_spec.rb
@@ -15,7 +15,8 @@ feature "authenticated user creates a an adventure using google maps", %(
 
   scenario "authenticated user successfully adds an adventure to an " +
     "existing bucket list with address only" do
-    bucket_list_sign_in
+    user = FactoryGirl.create(:user)
+    bucket_list_sign_in(user)
     visit new_adventure_path
     fill_in "Location", with: "Paris, France"
     click_button "Toss it in!"
@@ -26,7 +27,8 @@ feature "authenticated user creates a an adventure using google maps", %(
 
   scenario "authenticated user fails to add an adventure to an " +
     "existing bucket list with address only" do
-    bucket_list_sign_in
+    user = FactoryGirl.create(:user)
+    bucket_list_sign_in(user)
 
     visit new_adventure_path
     fill_in "Name", with: nil

--- a/spec/features/adventures/user_deletes_adventure_spec.rb
+++ b/spec/features/adventures/user_deletes_adventure_spec.rb
@@ -12,10 +12,7 @@ feature "authenticated user deletes an adventure", %(
 
   scenario "authenticated user sucessfully deletes an adventure" do
     user = FactoryGirl.create(:user)
-    visit new_user_session_path
-    fill_in "Email", with: user.email
-    fill_in "Password", with: user.password
-    click_button "Log in"
+    sign_in(user)
     bucket_list = FactoryGirl.create(
       :bucket_list,
       title: "Australia",

--- a/spec/features/adventures/user_edits_adventure_spec.rb
+++ b/spec/features/adventures/user_edits_adventure_spec.rb
@@ -16,7 +16,8 @@ feature "user edits adventure", %(
   # [x] I recieve a success message when I successfully edit an adventure
 
   scenario "authenticated user successfully edits an adventure" do
-    bucket_list_sign_in
+    user = FactoryGirl.create(:user)
+    bucket_list_sign_in(user)
     adventure = FactoryGirl.create(:adventure)
     FactoryGirl.create(
       :bucket_list_adventure,
@@ -42,10 +43,7 @@ feature "user edits adventure", %(
 
   scenario "authenticated user successfully edits an adventure's bucket list" do
     user = FactoryGirl.create(:user)
-    visit new_user_session_path
-    fill_in "Email", with: user.email
-    fill_in "Password", with: user.password
-    click_button "Log in"
+    sign_in(user)
     adventure = FactoryGirl.create(:adventure, user_id: user.id)
     bucket_list_1 = FactoryGirl.create(:bucket_list, user_id: user.id)
     bucket_list_2 = FactoryGirl.create(
@@ -68,8 +66,9 @@ feature "user edits adventure", %(
   end
 
   scenario "authenticated user successfully adds a link to an adventure" do
-    bucket_list_sign_in
-    adventure = FactoryGirl.create(:adventure)
+    user = FactoryGirl.create(:user)
+    bucket_list_sign_in(user)
+    adventure = FactoryGirl.create(:adventure, user_id: user.id)
 
     visit edit_adventure_path(adventure)
     fill_in "Link", with: "https://en.wikipedia.org/wiki/List_of_caves_in_Vietnam"
@@ -80,8 +79,9 @@ feature "user edits adventure", %(
   end
 
   scenario "authenticated user successfully adds a address to an adventure" do
-    bucket_list_sign_in
-    adventure = FactoryGirl.create(:adventure, address: nil)
+    user = FactoryGirl.create(:user)
+    bucket_list_sign_in(user)
+    adventure = FactoryGirl.create(:adventure, address: nil, user_id: user.id)
 
     visit edit_adventure_path(adventure)
     fill_in "Address", with: "Spain"
@@ -92,8 +92,9 @@ feature "user edits adventure", %(
   end
 
   scenario "authenticated user successfully adds a name to an adventure" do
-    bucket_list_sign_in
-    adventure = FactoryGirl.create(:adventure, name: nil)
+    user = FactoryGirl.create(:user)
+    bucket_list_sign_in(user)
+    adventure = FactoryGirl.create(:adventure, name: nil, user_id: user.id)
 
     visit edit_adventure_path(adventure)
     fill_in "Name", with: "Do this thing!"
@@ -114,8 +115,9 @@ feature "user edits adventure", %(
   end
 
   scenario "authenticated user fails to edit an adventure" do
-    bucket_list_sign_in
-    adventure = FactoryGirl.create(:adventure, address: nil)
+    user = FactoryGirl.create(:user)
+    bucket_list_sign_in(user)
+    adventure = FactoryGirl.create(:adventure, address: nil, user_id: user.id)
 
     visit edit_adventure_path(adventure)
     find("input[id$='adventure_name']").set ""
@@ -126,8 +128,9 @@ feature "user edits adventure", %(
   end
 
   scenario "authenticated user successfully removes adventure name attribute" do
-    bucket_list_sign_in
-    adventure = FactoryGirl.create(:adventure)
+    user = FactoryGirl.create(:user)
+    bucket_list_sign_in(user)
+    adventure = FactoryGirl.create(:adventure, user_id: user.id)
 
     visit edit_adventure_path(adventure)
     fill_in "Name", with: ""
@@ -139,8 +142,9 @@ feature "user edits adventure", %(
   end
 
   scenario "authenticated user successfully removes adventure address attribute" do
-    bucket_list_sign_in
-    adventure = FactoryGirl.create(:adventure)
+    user = FactoryGirl.create(:user)
+    bucket_list_sign_in(user)
+    adventure = FactoryGirl.create(:adventure, user_id: user.id)
 
     visit edit_adventure_path(adventure)
     fill_in "Name", with: "Eat tacos"

--- a/spec/features/adventures/user_views_adventure_spec.rb
+++ b/spec/features/adventures/user_views_adventure_spec.rb
@@ -86,6 +86,14 @@ feature "user views their adventures", %(
     expect(page).not_to have_content(adventure.name)
   end
 
+  scenario "authenticated user successfully views list of their adventures" \
+  " by navigating to the adventures index page" do
+  end
+
+  scenario "unauthenticated user fails to view list of their adventures" \
+  " by navigating to the adventures index page" do
+  end
+
   scenario "unauthenticated user successfully views list of public adventures" \
   " by navigating to the all_public adventures page" do
     # # bucket_list_1

--- a/spec/features/adventures/user_views_adventure_spec.rb
+++ b/spec/features/adventures/user_views_adventure_spec.rb
@@ -17,11 +17,7 @@ feature "user views their adventures", %(
   "associated w/ a particular bucket lists by navigating to that bucket" \
   " list's show page" do
     user = FactoryGirl.create(:user)
-    visit new_user_session_path
-    fill_in "Email", with: user.email
-    fill_in "Password", with: user.password
-    click_button "Log in"
-
+    sign_in(user)
     # bucket_list_1
     bucket_list_1 = FactoryGirl.create(:bucket_list, user_id: user.id)
     adventure_1 = FactoryGirl.create(
@@ -90,7 +86,7 @@ feature "user views their adventures", %(
   " by navigating to the adventures index page" do
     user = FactoryGirl.create(:user)
     sign_in(user)
-    
+
     # bucket_list_1
     bucket_list_1 = FactoryGirl.create(:bucket_list, user_id: user.id)
     adventure_1 = FactoryGirl.create(
@@ -248,10 +244,7 @@ feature "user views their adventures", %(
   scenario "authenticated user successfully switches an adventure from public" \
   " to private by clicking on the appropirate icon" do
     user = FactoryGirl.create(:user)
-    visit new_user_session_path
-    fill_in "Email", with: user.email
-    fill_in "Password", with: user.password
-    click_button "Log in"
+    sign_in(user)
 
     bucket_list = FactoryGirl.create(:bucket_list, user_id: user.id)
     adventure = FactoryGirl.create(

--- a/spec/features/adventures/user_views_adventure_spec.rb
+++ b/spec/features/adventures/user_views_adventure_spec.rb
@@ -90,7 +90,7 @@ feature "user views their adventures", %(
   " by navigating to the adventures index page" do
     user = FactoryGirl.create(:user)
     sign_in(user)
-
+    
     # bucket_list_1
     bucket_list_1 = FactoryGirl.create(:bucket_list, user_id: user.id)
     adventure_1 = FactoryGirl.create(

--- a/spec/features/adventures/user_views_adventure_spec.rb
+++ b/spec/features/adventures/user_views_adventure_spec.rb
@@ -90,7 +90,7 @@ feature "user views their adventures", %(
   " by navigating to the adventures index page" do
     user = FactoryGirl.create(:user)
     sign_in(user)
-    
+
     # bucket_list_1
     bucket_list_1 = FactoryGirl.create(:bucket_list, user_id: user.id)
     adventure_1 = FactoryGirl.create(
@@ -127,6 +127,42 @@ feature "user views their adventures", %(
 
   scenario "unauthenticated user fails to view list of their adventures" \
   " by navigating to the adventures index page" do
+    user = FactoryGirl.create(:user)
+
+    # bucket_list_1
+    bucket_list_1 = FactoryGirl.create(:bucket_list, user_id: user.id)
+    adventure_1 = FactoryGirl.create(
+      :adventure,
+      user_id: user.id
+    )
+    bucket_list_adventure_1 = FactoryGirl.create(
+      :bucket_list_adventure,
+      bucket_list_id: bucket_list_1.id,
+      adventure_id: adventure_1.id
+    )
+
+    # bucket_list_2
+    bucket_list_2 = FactoryGirl.create(
+      :bucket_list,
+      user_id: user.id,
+      title: "Mongolia"
+    )
+    adventure_2 = FactoryGirl.create(
+      :adventure,
+      user_id: user.id,
+      name: "Sleep in a yurt"
+    )
+    bucket_list_adventure_2 = FactoryGirl.create(
+      :bucket_list_adventure,
+      bucket_list_id: bucket_list_2.id,
+      adventure_id: adventure_2.id
+    )
+
+    visit adventures_path
+    expect(page).to have_content("You can do that after you sign in or sign up!")
+    expect(page).to have_content("Log in")
+    expect(page).not_to have_content(adventure_1.name)
+    expect(page).not_to have_content(adventure_2.name)
   end
 
   scenario "unauthenticated user successfully views list of public adventures" \

--- a/spec/features/adventures/user_views_adventure_spec.rb
+++ b/spec/features/adventures/user_views_adventure_spec.rb
@@ -88,6 +88,41 @@ feature "user views their adventures", %(
 
   scenario "authenticated user successfully views list of their adventures" \
   " by navigating to the adventures index page" do
+    user = FactoryGirl.create(:user)
+    sign_in(user)
+    
+    # bucket_list_1
+    bucket_list_1 = FactoryGirl.create(:bucket_list, user_id: user.id)
+    adventure_1 = FactoryGirl.create(
+      :adventure,
+      user_id: user.id
+    )
+    bucket_list_adventure_1 = FactoryGirl.create(
+      :bucket_list_adventure,
+      bucket_list_id: bucket_list_1.id,
+      adventure_id: adventure_1.id
+    )
+
+    # bucket_list_2
+    bucket_list_2 = FactoryGirl.create(
+      :bucket_list,
+      user_id: user.id,
+      title: "Mongolia"
+    )
+    adventure_2 = FactoryGirl.create(
+      :adventure,
+      user_id: user.id,
+      name: "Sleep in a yurt"
+    )
+    bucket_list_adventure_2 = FactoryGirl.create(
+      :bucket_list_adventure,
+      bucket_list_id: bucket_list_2.id,
+      adventure_id: adventure_2.id
+    )
+
+    visit adventures_path
+    expect(page).to have_content(adventure_1.name)
+    expect(page).to have_content(adventure_2.name)
   end
 
   scenario "unauthenticated user fails to view list of their adventures" \

--- a/spec/features/bucket_lists/user_creates_bucket_list_spec.rb
+++ b/spec/features/bucket_lists/user_creates_bucket_list_spec.rb
@@ -16,7 +16,8 @@ feature 'authenticated user creates a bucket list', %(
 # [x] I must be signed in to create the list
 
   scenario "authenticated user successfully creates a bucket list" do
-    sign_in
+    user = FactoryGirl.create(:user)
+    sign_in(user)
     visit new_bucket_list_path
     fill_in "Title", with: "Europe"
     click_button "Save It!"
@@ -37,7 +38,8 @@ feature 'authenticated user creates a bucket list', %(
   end
 
   scenario "authenticated user fails to sucessfully create a bucket list" do
-    sign_in
+    user = FactoryGirl.create(:user)
+    sign_in(user)
     visit new_bucket_list_path
     click_button "Save It!"
 

--- a/spec/features/bucket_lists/user_deletes_bucket_list_spec.rb
+++ b/spec/features/bucket_lists/user_deletes_bucket_list_spec.rb
@@ -11,9 +11,8 @@ feature "authenticated user deletes a bucket list", %(
 # [x] After I delete a bucket list it is no longer visible
 
   scenario "authenticated user sucessfully deletes a bucket list" do
-    bucket_list = FactoryGirl.create(:bucket_list)
-
-    sign_in
+    user = FactoryGirl.create(:user)
+    bucket_list_sign_in(user)
     visit edit_bucket_list_path(bucket_list)
     click_link "Delete"
 

--- a/spec/features/bucket_lists/user_deletes_bucket_list_spec.rb
+++ b/spec/features/bucket_lists/user_deletes_bucket_list_spec.rb
@@ -12,8 +12,9 @@ feature "authenticated user deletes a bucket list", %(
 
   scenario "authenticated user sucessfully deletes a bucket list" do
     user = FactoryGirl.create(:user)
-    bucket_list_sign_in(user)
-    visit edit_bucket_list_path(bucket_list)
+    bucket_list = FactoryGirl.create(:bucket_list, user_id: user.id)
+    sign_in(user)
+    visit edit_bucket_list_path(bucket_list.id)
     click_link "Delete"
 
     expect(page).to have_content("Bucket List deleted")

--- a/spec/features/bucket_lists/user_edits_bucket_lists_spec.rb
+++ b/spec/features/bucket_lists/user_edits_bucket_lists_spec.rb
@@ -11,9 +11,8 @@ feature "authenticated user edits a bucket list", %(
 # [x] I can toggle between private and public
 
   scenario "user successfully changes the title of a bucket list" do
-    bucket_list = FactoryGirl.create(:bucket_list)
-
-    sign_in
+    user = FactoryGirl.create(:user)
+    bucket_list_sign_in(user)
     visit edit_bucket_list_path(bucket_list)
     fill_in "Title", with: "Africa"
     fill_in "Description", with: "Much warmer!"
@@ -25,9 +24,8 @@ feature "authenticated user edits a bucket list", %(
   end
 
   scenario "user successfully changes the private setting of a bucket list" do
-    bucket_list = FactoryGirl.create(:bucket_list)
-
-    sign_in
+    user = FactoryGirl.create(:user)
+    bucket_list_sign_in(user)
     visit edit_bucket_list_path(bucket_list)
     find("label", text: "Make public").click
     click_button "Save It!"

--- a/spec/features/bucket_lists/user_edits_bucket_lists_spec.rb
+++ b/spec/features/bucket_lists/user_edits_bucket_lists_spec.rb
@@ -12,8 +12,9 @@ feature "authenticated user edits a bucket list", %(
 
   scenario "user successfully changes the title of a bucket list" do
     user = FactoryGirl.create(:user)
-    bucket_list_sign_in(user)
-    visit edit_bucket_list_path(bucket_list)
+    bucket_list = FactoryGirl.create(:bucket_list, user_id: user.id)
+    sign_in(user)
+    visit edit_bucket_list_path(bucket_list.id)
     fill_in "Title", with: "Africa"
     fill_in "Description", with: "Much warmer!"
     click_button "Save It!"
@@ -25,8 +26,9 @@ feature "authenticated user edits a bucket list", %(
 
   scenario "user successfully changes the private setting of a bucket list" do
     user = FactoryGirl.create(:user)
-    bucket_list_sign_in(user)
-    visit edit_bucket_list_path(bucket_list)
+    bucket_list = FactoryGirl.create(:bucket_list, user_id: user.id)
+    sign_in(user)
+    visit edit_bucket_list_path(bucket_list.id)
     find("label", text: "Make public").click
     click_button "Save It!"
 

--- a/spec/support/bucket_list_sign_in_helper.rb
+++ b/spec/support/bucket_list_sign_in_helper.rb
@@ -1,7 +1,5 @@
 module BucketListSignIn
-  def bucket_list_sign_in
-    user = FactoryGirl.create(:user)
-
+  def bucket_list_sign_in(user)
     visit new_user_session_path
     fill_in 'Email', with: user.email
     fill_in 'Password', with: user.password

--- a/spec/support/user_sign_in_helper.rb
+++ b/spec/support/user_sign_in_helper.rb
@@ -1,15 +1,5 @@
 module UserSignIn
-  def sign_in
-    user = FactoryGirl.create(:user)
-
-    visit new_user_session_path
-    fill_in 'Email', with: user.email
-    fill_in 'Password', with: user.password
-
-    click_button 'Log in'
-  end
-
-  def user_sign_in(user)
+  def sign_in(user)
     visit new_user_session_path
     fill_in 'Email', with: user.email
     fill_in 'Password', with: user.password
@@ -18,9 +8,7 @@ module UserSignIn
   end
 
 
-  def sign_in_with_adventures
-    user = FactoryGirl.create(:user)
-
+  def sign_in_with_adventures(user)
     visit new_user_session_path
     fill_in 'Email', with: user.email
     fill_in 'Password', with: user.password

--- a/spec/support/user_sign_in_helper.rb
+++ b/spec/support/user_sign_in_helper.rb
@@ -9,6 +9,15 @@ module UserSignIn
     click_button 'Log in'
   end
 
+  def user_sign_in(user)
+    visit new_user_session_path
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: user.password
+
+    click_button 'Log in'
+  end
+
+
   def sign_in_with_adventures
     user = FactoryGirl.create(:user)
 


### PR DESCRIPTION
- create & pass feature tests for authenticated user views adventures index page & unauthenticated user fails to view adventures index page
- refactor sign_in and bucket_list_sign_in helpers to accept argument for user
- adjust all feature tests to reflect sign_in helpers now accepting argument for user
- add adventures index page & iterate through @adventures to display adventures
